### PR TITLE
Add a_(time unit)_before and a_(time_unit)_after

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ iex(4)> 60 |> seconds_ago
 Update your `mix.exs` file and run `mix deps.get`.
 ```elixir
 defp deps do
-  [{:good_times, "~> 0.4.0"}]
+  [{:good_times, "~> 0.5.0"}]
 end
 ```
 

--- a/lib/good_times.ex
+++ b/lib/good_times.ex
@@ -219,6 +219,17 @@ defmodule GoodTimes do
   def hours_after(hours, datetime), do: seconds_after(hours * @seconds_per_hour, datetime)
 
   @doc """
+  Returns the UTC date and time an hour after the given datetime.
+
+  ## Examples
+
+      iex> an_hour_after {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 2, 27}, {19, 30, 45}}
+  """
+  @spec an_hour_after(datetime) :: datetime
+  def an_hour_after(datetime), do: seconds_after(@seconds_per_hour, datetime)
+
+  @doc """
   Returns the UTC date and time the specified hours before the given datetime.
 
   ## Examples
@@ -228,6 +239,17 @@ defmodule GoodTimes do
   """
   @spec hours_before(integer, datetime) :: datetime
   def hours_before(hours, datetime), do: seconds_before(hours * @seconds_per_hour, datetime)
+
+  @doc """
+  Returns the UTC date and time an hour before the given datetime.
+
+  ## Examples
+
+      iex> an_hour_before {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 2, 27}, {17, 30, 45}}
+  """
+  @spec an_hour_before(datetime) :: datetime
+  def an_hour_before(datetime), do: seconds_before(@seconds_per_hour, datetime)
 
   @doc """
   Returns the UTC date and time the specified hours from now.

--- a/lib/good_times.ex
+++ b/lib/good_times.ex
@@ -307,6 +307,17 @@ defmodule GoodTimes do
   def days_after(days, datetime), do: seconds_after(days * @seconds_per_day, datetime)
 
   @doc """
+  Returns the UTC date and time a day after the given datetime.
+
+  ## Examples
+
+      iex> a_day_after {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 2, 28}, {18, 30, 45}}
+  """
+  @spec a_day_after(datetime) :: datetime
+  def a_day_after(datetime), do: seconds_after(@seconds_per_day, datetime)
+
+  @doc """
   Returns the UTC date and time the specified days before the given datetime.
 
   ## Examples
@@ -316,6 +327,17 @@ defmodule GoodTimes do
   """
   @spec days_before(integer, datetime) :: datetime
   def days_before(days, datetime), do: seconds_before(days * @seconds_per_day, datetime)
+
+  @doc """
+  Returns the UTC date and time a day before the given datetime.
+
+  ## Examples
+
+      iex> a_day_before {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 2, 26}, {18, 30, 45}}
+  """
+  @spec a_day_before(datetime) :: datetime
+  def a_day_before(datetime), do: seconds_before(@seconds_per_day, datetime)
 
   @doc """
   Returns the UTC date and time the specified days from now.

--- a/lib/good_times.ex
+++ b/lib/good_times.ex
@@ -131,6 +131,17 @@ defmodule GoodTimes do
   def minutes_after(minutes, datetime), do: seconds_after(minutes * @seconds_per_minute, datetime)
 
   @doc """
+  Returns the UTC date and time a minute after the given datetime.
+
+  ## Examples
+
+      iex> a_minute_after {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 2, 27}, {18, 31, 45}}
+  """
+  @spec a_minute_after(datetime) :: datetime
+  def a_minute_after(datetime), do: seconds_after(@seconds_per_minute, datetime)
+
+  @doc """
   Returns the UTC date and time the specified minutes before the given datetime.
 
   ## Examples
@@ -140,6 +151,17 @@ defmodule GoodTimes do
   """
   @spec minutes_before(integer, datetime) :: datetime
   def minutes_before(minutes, datetime), do: seconds_before(minutes * @seconds_per_minute, datetime)
+
+  @doc """
+  Returns the UTC date and time a minute before the given datetime.
+
+  ## Examples
+
+      iex> a_minute_before {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 2, 27}, {18, 29, 45}}
+  """
+  @spec a_minute_before(datetime) :: datetime
+  def a_minute_before(datetime), do: seconds_before(@seconds_per_minute, datetime)
 
   @doc """
   Returns the UTC date and time the specified minutes from now.

--- a/lib/good_times.ex
+++ b/lib/good_times.ex
@@ -139,7 +139,7 @@ defmodule GoodTimes do
       {{2015, 2, 27}, {18, 31, 45}}
   """
   @spec a_minute_after(datetime) :: datetime
-  def a_minute_after(datetime), do: seconds_after(@seconds_per_minute, datetime)
+  def a_minute_after(datetime), do: minutes_after(1, datetime)
 
   @doc """
   Returns the UTC date and time the specified minutes before the given datetime.
@@ -161,7 +161,7 @@ defmodule GoodTimes do
       {{2015, 2, 27}, {18, 29, 45}}
   """
   @spec a_minute_before(datetime) :: datetime
-  def a_minute_before(datetime), do: seconds_before(@seconds_per_minute, datetime)
+  def a_minute_before(datetime), do: minutes_before(1, datetime)
 
   @doc """
   Returns the UTC date and time the specified minutes from now.
@@ -227,7 +227,7 @@ defmodule GoodTimes do
       {{2015, 2, 27}, {19, 30, 45}}
   """
   @spec an_hour_after(datetime) :: datetime
-  def an_hour_after(datetime), do: seconds_after(@seconds_per_hour, datetime)
+  def an_hour_after(datetime), do: hours_after(1, datetime)
 
   @doc """
   Returns the UTC date and time the specified hours before the given datetime.
@@ -249,7 +249,7 @@ defmodule GoodTimes do
       {{2015, 2, 27}, {17, 30, 45}}
   """
   @spec an_hour_before(datetime) :: datetime
-  def an_hour_before(datetime), do: seconds_before(@seconds_per_hour, datetime)
+  def an_hour_before(datetime), do: hours_before(1, datetime)
 
   @doc """
   Returns the UTC date and time the specified hours from now.
@@ -315,7 +315,7 @@ defmodule GoodTimes do
       {{2015, 2, 28}, {18, 30, 45}}
   """
   @spec a_day_after(datetime) :: datetime
-  def a_day_after(datetime), do: seconds_after(@seconds_per_day, datetime)
+  def a_day_after(datetime), do: days_after(1, datetime)
 
   @doc """
   Returns the UTC date and time the specified days before the given datetime.
@@ -337,7 +337,7 @@ defmodule GoodTimes do
       {{2015, 2, 26}, {18, 30, 45}}
   """
   @spec a_day_before(datetime) :: datetime
-  def a_day_before(datetime), do: seconds_before(@seconds_per_day, datetime)
+  def a_day_before(datetime), do: days_before(1, datetime)
 
   @doc """
   Returns the UTC date and time the specified days from now.

--- a/lib/good_times.ex
+++ b/lib/good_times.ex
@@ -46,6 +46,17 @@ defmodule GoodTimes do
   end
 
   @doc """
+  Returns the UTC date and time a second after the given datetime.
+
+  ## Examples
+
+      iex> a_second_after {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 2, 27}, {18, 30, 46}}
+  """
+  @spec a_second_after(datetime) :: datetime
+  def a_second_after(datetime), do: seconds_after(1, datetime)
+
+  @doc """
   Returns the UTC date and time the specified seconds before the given datetime.
 
   ## Examples
@@ -55,6 +66,17 @@ defmodule GoodTimes do
   """
   @spec seconds_before(integer, datetime) :: datetime
   def seconds_before(seconds, datetime), do: seconds_after(-seconds, datetime)
+
+  @doc """
+  Returns the UTC date and time a second before the given datetime.
+
+  ## Examples
+
+      iex> a_second_before {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 2, 27}, {18, 30, 44}}
+  """
+  @spec a_second_before(datetime) :: datetime
+  def a_second_before(datetime), do: seconds_before(1, datetime)
 
   @doc """
   Returns the UTC date and time the specified seconds from now.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GoodTimes.Mixfile do
   def project do
     [
       app: :good_times,
-      version: "0.4.0",
+      version: "0.5.0",
       name: "GoodTimes",
       source_url: "https://github.com/magplus/good_times",
       elixir: "~> 1.0",

--- a/test/good_times_test.exs
+++ b/test/good_times_test.exs
@@ -77,6 +77,20 @@ defmodule GoodTimesTest do
     assert actual == expected
   end
 
+  test "a_minute_after" do
+    expected = {0, {0, 1, 0}}
+    actual = difference @a_datetime, a_minute_after(@a_datetime)
+
+    assert actual == expected
+  end
+
+  test "a_minute_before" do
+    expected = {-1, {23, 59, 0}}
+    actual = difference @a_datetime, a_minute_before(@a_datetime)
+
+    assert actual == expected
+  end
+
   test "seconds_from_now" do
     expected = {0, {0, 0, 10}}
     actual = difference now, seconds_from_now(10)

--- a/test/good_times_test.exs
+++ b/test/good_times_test.exs
@@ -105,6 +105,20 @@ defmodule GoodTimesTest do
     assert actual == expected
   end
 
+  test "a_day_after" do
+    expected = {1, {0, 0, 0}}
+    actual = difference @a_datetime, a_day_after(@a_datetime)
+
+    assert actual == expected
+  end
+
+  test "a_day_before" do
+    expected = {-1, {0, 0, 0}}
+    actual = difference @a_datetime, a_day_before(@a_datetime)
+
+    assert actual == expected
+  end
+
   test "seconds_from_now" do
     expected = {0, {0, 0, 10}}
     actual = difference now, seconds_from_now(10)

--- a/test/good_times_test.exs
+++ b/test/good_times_test.exs
@@ -91,6 +91,20 @@ defmodule GoodTimesTest do
     assert actual == expected
   end
 
+  test "an_hour_after" do
+    expected = {0, {1, 0, 0}}
+    actual = difference @a_datetime, an_hour_after(@a_datetime)
+
+    assert actual == expected
+  end
+
+  test "an_hour_before" do
+    expected = {-1, {23, 0, 0}}
+    actual = difference @a_datetime, an_hour_before(@a_datetime)
+
+    assert actual == expected
+  end
+
   test "seconds_from_now" do
     expected = {0, {0, 0, 10}}
     actual = difference now, seconds_from_now(10)

--- a/test/good_times_test.exs
+++ b/test/good_times_test.exs
@@ -63,6 +63,20 @@ defmodule GoodTimesTest do
     assert actual == expected
   end
 
+  test "a_second_after" do
+    expected = {0, {0, 0, 1}}
+    actual = difference @a_datetime, a_second_after(@a_datetime)
+
+    assert actual == expected
+  end
+
+  test "a_second_before" do
+    expected = {-1, {23, 59, 59}}
+    actual = difference @a_datetime, a_second_before(@a_datetime)
+
+    assert actual == expected
+  end
+
   test "seconds_from_now" do
     expected = {0, {0, 0, 10}}
     actual = difference now, seconds_from_now(10)


### PR DESCRIPTION
To be consistent with functions like `a_second_from_now`, this PR adds the following functions:

+ a_second_after/1
+ a_second_before/1
+ a_minute_after/1
+ a_minute_before/1
+ an_hour_after/1
+ an_hour_before/1
+ a_day_after/1
+ a_day_before/1

Version gets bumped to 0.5.0.