### PR TITLE
Remove duplication in tests

### DIFF
--- a/test/good_times_test.exs
+++ b/test/good_times_test.exs
@@ -8,286 +8,176 @@ defmodule GoodTimesTest do
 
   @a_datetime {{2015, 2, 27}, {18, 30, 45}}
   test "seconds_after" do
-    expected = {0, {0, 0, 10}}
-    actual = difference @a_datetime, seconds_after(10, @a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, seconds_after(10, @a_datetime), {0, {0, 0, 10}}
   end
 
   test "seconds_before" do
-    expected = {-1, {23, 59, 50}}
-    actual = difference @a_datetime, seconds_before(10, @a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, seconds_before(10, @a_datetime), {-1, {23, 59, 50}}
   end
 
   test "a_second_after" do
-    expected = {0, {0, 0, 1}}
-    actual = difference @a_datetime, a_second_after(@a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, a_second_after(@a_datetime), {0, {0, 0, 1}}
   end
 
   test "a_second_before" do
-    expected = {-1, {23, 59, 59}}
-    actual = difference @a_datetime, a_second_before(@a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, a_second_before(@a_datetime), {-1, {23, 59, 59}}
   end
 
   test "seconds_from_now" do
-    expected = {0, {0, 0, 10}}
-    actual = difference now, seconds_from_now(10)
-
-    assert actual == expected
+    assert_difference seconds_from_now(10), {0, {0, 0, 10}}
   end
 
   test "seconds_ago" do
-    expected = {-1, {23, 59, 45}}
-    actual = difference now, seconds_ago(15)
-
-    assert actual == expected
+    assert_difference seconds_ago(15), {-1, {23, 59, 45}}
   end
 
   test "a_second_from_now" do
-    expected = {0, {0, 0, 1}}
-    actual = difference now, a_second_from_now
-
-    assert actual == expected
+    assert_difference a_second_from_now, {0, {0, 0, 1}}
   end
 
   test "a_second_ago" do
-    expected = {-1, {23, 59, 59}}
-    actual = difference now, a_second_ago
-
-    assert actual == expected
+    assert_difference a_second_ago, {-1, {23, 59, 59}}
   end
 
   test "minutes_after" do
-    expected = {0, {0, 10, 0}}
-    actual = difference @a_datetime, minutes_after(10, @a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, minutes_after(10, @a_datetime), {0, {0, 10, 0}}
   end
 
   test "minutes_before" do
-    expected = {-1, {23, 50, 0}}
-    actual = difference @a_datetime, minutes_before(10, @a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, minutes_before(10, @a_datetime), {-1, {23, 50, 0}}
   end
 
   test "a_minute_after" do
-    expected = {0, {0, 1, 0}}
-    actual = difference @a_datetime, a_minute_after(@a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, a_minute_after(@a_datetime), {0, {0, 1, 0}}
   end
 
   test "a_minute_before" do
-    expected = {-1, {23, 59, 0}}
-    actual = difference @a_datetime, a_minute_before(@a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, a_minute_before(@a_datetime), {-1, {23, 59, 0}}
   end
 
   test "minutes_from_now" do
-    expected = {0, {0, 5, 0}}
-    actual = difference now, minutes_from_now(5)
-
-    assert actual == expected
+    assert_difference minutes_from_now(5), {0, {0, 5, 0}}
   end
 
   test "minutes_ago" do
-    expected = {-1, {23, 40, 0}}
-    actual = difference now, minutes_ago(20)
-
-    assert actual == expected
+    assert_difference minutes_ago(20), {-1, {23, 40, 0}}
   end
 
   test "a_minute_from_now" do
-    expected = {0, {0, 1, 0}}
-    actual = difference now, a_minute_from_now
-
-    assert actual == expected
+    assert_difference a_minute_from_now, {0, {0, 1, 0}}
   end
 
   test "a_minute_ago" do
-    expected = {-1, {23, 59, 0}}
-    actual = difference now, a_minute_ago
-
-    assert actual == expected
+    assert_difference a_minute_ago, {-1, {23, 59, 0}}
   end
 
   test "hours_after" do
-    expected = {0, {10, 0, 0}}
-    actual = difference @a_datetime, hours_after(10, @a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, hours_after(10, @a_datetime), {0, {10, 0, 0}}
   end
 
   test "hours_before" do
-    expected = {-1, {14, 0, 0}}
-    actual = difference @a_datetime, hours_before(10, @a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, hours_before(10, @a_datetime), {-1, {14, 0, 0}}
   end
 
   test "an_hour_after" do
-    expected = {0, {1, 0, 0}}
-    actual = difference @a_datetime, an_hour_after(@a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, an_hour_after(@a_datetime), {0, {1, 0, 0}}
   end
 
   test "an_hour_before" do
-    expected = {-1, {23, 0, 0}}
-    actual = difference @a_datetime, an_hour_before(@a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, an_hour_before(@a_datetime), {-1, {23, 0, 0}}
   end
 
   test "hours_from_now" do
-    expected = {0, {2, 0, 0}}
-    actual = difference now, hours_from_now(2)
-
-    assert actual == expected
+    assert_difference hours_from_now(2), {0, {2, 0, 0}}
   end
 
   test "hours_ago" do
-    expected = {-1, {20, 0, 0}}
-    actual = difference now, hours_ago(4)
-
-    assert actual == expected
+    assert_difference hours_ago(4), {-1, {20, 0, 0}}
   end
 
   test "an_hour_from_now" do
-    expected = {0, {1, 0, 0}}
-    actual = difference now, an_hour_from_now
-
-    assert actual == expected
+    assert_difference an_hour_from_now, {0, {1, 0, 0}}
   end
 
   test "an_hour_ago" do
-    expected = {-1, {23, 0, 0}}
-    actual = difference now, an_hour_ago
-
-    assert actual == expected
+    assert_difference an_hour_ago, {-1, {23, 0, 0}}
   end
 
   test "days_after" do
-    expected = {3, {0, 0, 0}}
-    actual = difference @a_datetime, days_after(3, @a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, days_after(3, @a_datetime), {3, {0, 0, 0}}
   end
 
   test "days_before" do
-    expected = {-3, {0, 0, 0}}
-    actual = difference @a_datetime, days_before(3, @a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, days_before(3, @a_datetime), {-3, {0, 0, 0}}
   end
 
   test "a_day_after" do
-    expected = {1, {0, 0, 0}}
-    actual = difference @a_datetime, a_day_after(@a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, a_day_after(@a_datetime), {1, {0, 0, 0}}
   end
 
   test "a_day_before" do
-    expected = {-1, {0, 0, 0}}
-    actual = difference @a_datetime, a_day_before(@a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, a_day_before(@a_datetime), {-1, {0, 0, 0}}
   end
 
   test "days_from_now" do
-    expected = {3, {0, 0, 0}}
-    actual = difference now, days_from_now(3)
-
-    assert actual == expected
+    assert_difference days_from_now(3), {3, {0, 0, 0}}
   end
 
   test "days_ago" do
-    expected = {-7, {0, 0, 0}}
-    actual = difference now, days_ago(7)
-
-    assert actual == expected
+    assert_difference days_ago(7), {-7, {0, 0, 0}}
   end
 
   test "a_day_from_now" do
-    expected = {1, {0, 0, 0}}
-    actual = difference now, a_day_from_now
-
-    assert actual == expected
+    assert_difference a_day_from_now, {1, {0, 0, 0}}
   end
 
   test "a_day_ago" do
-    expected = {-1, {0, 0, 0}}
-    actual = difference now, a_day_ago
-
-    assert actual == expected
+    assert_difference a_day_ago, {-1, {0, 0, 0}}
   end
 
   test "weeks_after" do
-    expected = {28, {0, 0, 0}}
-    actual = difference @a_datetime, weeks_after(4, @a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, weeks_after(4, @a_datetime), {28, {0, 0, 0}}
   end
 
   test "weeks_before" do
-    expected = {-28, {0, 0, 0}}
-    actual = difference @a_datetime, weeks_before(4, @a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, weeks_before(4, @a_datetime), {-28, {0, 0, 0}}
   end
 
   test "a_week_after" do
-    expected = {7, {0, 0, 0}}
-    actual = difference @a_datetime, a_week_after(@a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, a_week_after(@a_datetime), {7, {0, 0, 0}}
   end
 
   test "a_week_before" do
-    expected = {-7, {0, 0, 0}}
-    actual = difference @a_datetime, a_week_before(@a_datetime)
-
-    assert actual == expected
+    assert_difference @a_datetime, a_week_before(@a_datetime), {-7, {0, 0, 0}}
   end
 
   test "weeks_from_now" do
-    expected = {28, {0, 0, 0}}
-    actual = difference now, weeks_from_now(4)
-
-    assert actual == expected
+    assert_difference weeks_from_now(4), {28, {0, 0, 0}}
   end
 
   test "weeks_ago" do
-    expected = {-28, {0, 0, 0}}
-    actual = difference now, weeks_ago(4)
-
-    assert actual == expected
+    assert_difference weeks_ago(4), {-28, {0, 0, 0}}
   end
 
   test "a_week_from_now" do
-    expected = {7, {0, 0, 0}}
-    actual = difference now, a_week_from_now
-
-    assert actual == expected
+    assert_difference a_week_from_now, {7, {0, 0, 0}}
   end
 
   test "a_week_ago" do
-    expected = {-7, {0, 0, 0}}
-    actual = difference now, a_week_ago
-
-    assert actual == expected
+    assert_difference a_week_ago, {-7, {0, 0, 0}}
   end
 
   defp difference(t1, t2) do
     :calendar.time_difference t1, t2
+  end
+
+  defp assert_difference(datetime, expected) do
+    actual = difference now, datetime
+    assert actual == expected
+  end
+
+  defp assert_difference(datetime1 , datetime2, expected) do
+    actual = difference datetime1, datetime2
+    assert actual == expected
   end
 end

--- a/test/good_times_test.exs
+++ b/test/good_times_test.exs
@@ -172,8 +172,7 @@ defmodule GoodTimesTest do
   end
 
   defp assert_difference(datetime, expected) do
-    actual = difference now, datetime
-    assert actual == expected
+    assert_difference now, datetime, expected
   end
 
   defp assert_difference(datetime1 , datetime2, expected) do


### PR DESCRIPTION
Almost all tests repeat the same pattern. Specify expected time difference,
compute actual difference, assert equality. I've extracted this to a function,
passing in the datetimes (or datetime, if we're comparing to `now`), and the
expected difference.

I find that it doesn't hurt readability much, even on slightly long lines, and
it makes the tests easier to scan.