### PR TITLE
Add month functions

### DIFF
--- a/lib/good_times.ex
+++ b/lib/good_times.ex
@@ -471,4 +471,51 @@ defmodule GoodTimes do
   """
   @spec a_week_ago :: datetime
   def a_week_ago, do: weeks_ago(1)
+
+  @doc """
+  Returns the UTC date and time the specified months after the given datetime.
+
+  ## Examples
+
+      iex> 3 |> months_after {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 5, 27}, {18, 30, 45}}
+  """
+  @spec months_after(integer, datetime) :: datetime
+  def months_after(months, {{year, month, day}, time}) do
+    {new_year, new_month} = new_year_and_month year, month, months
+    ldom = :calendar.last_day_of_the_month(new_year, new_month)
+    if day <= ldom do
+      {{new_year, new_month, day}, time}
+    else
+      {{new_year, new_month, ldom}, time}
+    end
+  end
+
+  defp new_year_and_month(year, month, months) when months >= 0 do
+    {year, month}
+      |> Stream.unfold(fn ym -> {ym, next_month ym} end)
+      |> Enum.at months
+  end
+
+  defp new_year_and_month(year, month, months) when months < 0 do
+    {year, month}
+      |> Stream.unfold(fn ym -> {ym, previous_month ym} end)
+      |> Enum.at -months
+  end
+
+  defp next_month({year, 12}), do: {year + 1, 1}
+  defp next_month({year, month}), do: {year, month + 1}
+  defp previous_month({year, 1}), do: {year - 1, 12}
+  defp previous_month({year, month}), do: {year, month - 1}
+
+  @doc """
+  Returns the UTC date and time the specified months before the given datetime.
+
+  ## Examples
+
+      iex> 3 |> months_before {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 5, 27}, {18, 30, 45}}
+  """
+  @spec months_before(integer, datetime) :: datetime
+  def months_before(months, datetime), do: months_after(-months, datetime)
 end

--- a/lib/good_times.ex
+++ b/lib/good_times.ex
@@ -519,7 +519,7 @@ defmodule GoodTimes do
   ## Examples
 
       iex> 3 |> months_before {{2015, 2, 27}, {18, 30, 45}}
-      {{2015, 5, 27}, {18, 30, 45}}
+      {{2014, 11, 27}, {18, 30, 45}}
   """
   @spec months_before(integer, datetime) :: datetime
   def months_before(months, datetime), do: months_after(-months, datetime)

--- a/lib/good_times.ex
+++ b/lib/good_times.ex
@@ -518,4 +518,70 @@ defmodule GoodTimes do
   """
   @spec months_before(integer, datetime) :: datetime
   def months_before(months, datetime), do: months_after(-months, datetime)
+
+  @doc """
+  Returns the UTC date and time a month after the given datetime.
+
+  ## Examples
+
+      iex> a_month_after {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 3, 27}, {18, 30, 45}}
+  """
+  @spec a_month_after(datetime) :: datetime
+  def a_month_after(datetime), do: months_after(1, datetime)
+
+  @doc """
+  Returns the UTC date and time a month before the given datetime.
+
+  ## Examples
+
+      iex> a_month_before {{2015, 2, 27}, {18, 30, 45}}
+      {{2015, 1, 27}, {18, 30, 45}}
+  """
+  @spec a_month_before(datetime) :: datetime
+  def a_month_before(datetime), do: months_before(1, datetime)
+
+  @doc """
+  Returns the UTC date and time the specified months from now.
+
+  ## Examples
+
+      iex> 2 |> months_from_now
+      {{2015, 4, 27}, {18, 30, 45}}
+  """
+  @spec months_from_now(integer) :: datetime
+  def months_from_now(months), do: months_after(months, now)
+
+  @doc """
+  Returns the UTC date and time the specified months ago.
+
+  ## Examples
+
+      iex> 2 |> months_ago
+      {{2014, 12, 27}, {18, 30, 45}}
+  """
+  @spec months_ago(integer) :: datetime
+  def months_ago(months), do: months_before(months, now)
+
+  @doc """
+  Returns the UTC date and time a month from now.
+
+   ## Examples
+
+      iex> a_month_from_now
+      {{2015, 3, 27}, {18, 30, 45}}
+  """
+  @spec a_month_from_now :: datetime
+  def a_month_from_now, do: months_from_now(1)
+
+  @doc """
+  Returns the UTC date and time a month ago.
+
+   ## Examples
+
+      iex> a_month_ago
+      {{2015, 1, 27}, {18, 30, 45}}
+  """
+  @spec a_month_ago :: datetime
+  def a_month_ago, do: months_ago(1)
 end

--- a/test/good_times_test.exs
+++ b/test/good_times_test.exs
@@ -167,6 +167,21 @@ defmodule GoodTimesTest do
     assert_difference a_week_ago, {-7, {0, 0, 0}}
   end
 
+  @last_jan_2015 {{2015, 1, 31}, {12, 0, 0}}
+  test "months_after" do
+    assert months_after(1, @a_datetime) == {{2015, 3, 27}, {18, 30, 45}}
+    assert months_after(1, @last_jan_2015) == {{2015, 2, 28}, {12, 0, 0}}
+    assert months_after(12, @last_jan_2015) == {{2016, 1, 31}, {12, 0, 0}}
+    assert months_after(13, @last_jan_2015) == {{2016, 2, 29}, {12, 0, 0}}
+  end
+
+  test "months_before" do
+    assert months_before(1, @a_datetime) == {{2015, 1, 27}, {18, 30, 45}}
+    assert months_before(1, @last_jan_2015) == {{2014, 12, 31}, {12, 0, 0}}
+    assert months_before(12, @last_jan_2015) == {{2014, 1, 31}, {12, 0, 0}}
+    assert months_before(11, @last_jan_2015) == {{2014, 2, 28}, {12, 0, 0}}
+  end
+
   defp difference(t1, t2) do
     :calendar.time_difference t1, t2
   end

--- a/test/good_times_test.exs
+++ b/test/good_times_test.exs
@@ -182,6 +182,14 @@ defmodule GoodTimesTest do
     assert months_before(11, @last_jan_2015) == {{2014, 2, 28}, {12, 0, 0}}
   end
 
+  test "a_month_after" do
+    assert_difference @a_datetime, a_month_after(@a_datetime), {28, {0, 0, 0}}
+  end
+
+  test "a_month_before" do
+    assert_difference @a_datetime, a_month_before(@a_datetime), {-31, {0, 0, 0}}
+  end
+
   defp difference(t1, t2) do
     :calendar.time_difference t1, t2
   end


### PR DESCRIPTION
Fun to implement, less fun to test. I finally landed in a functional approach to calculating month offsets from dates. I pick a new date from a `Stream.unfold` that generates the next or previous month. The day part is naive and so we pipe to a function that adjusts it using `:calendar.last_day_of_the_month`.

Here's the problem: Half of the functions are relative to now. So far, we've tested these as we can calculate a fixed time difference. This isn't possible here. Expecting a 31 day diff would break as soon as we enter April. We haven't figured out how to freeze time à la Timecop, but we only need the simplest uses, which are really equivalent to mocking.

I didn't add [mock](https://github.com/jjh42/mock) as a dependency, as I hoped you might have an idea on how to test `a_month_ago` and friends. Right now, these functions are simply left untested (gasp! :speak_no_evil:)