### PR TITLE
Add "at" function for adjusting a datetime given a time.

### DIFF
--- a/lib/good_times.ex
+++ b/lib/good_times.ex
@@ -20,7 +20,9 @@ defmodule GoodTimes do
   @type hour   :: 0..23
   @type minute :: 0..59
   @type second :: 0..59
-  @type datetime :: {{year, month, day}, {hour, minute, second}}
+  @type date :: {year, month, day}
+  @type time :: {hour, minute, second}
+  @type datetime :: {date, time}
 
   @doc """
   Returns the current UTC time as a datetime.
@@ -32,6 +34,17 @@ defmodule GoodTimes do
   """
   @spec now :: datetime
   def now, do: :calendar.universal_time
+
+  @doc """
+  Merges the date from the given datetime with another time.
+
+  ## Examples
+
+      iex> now |> at {10, 30, 15}
+      {{2015, 2, 27}, {10, 30, 15}}
+  """
+  @spec at(datetime, time) :: datetime
+  def at({date, _}, time), do: {date, time}
 
   @doc """
   Returns the UTC date and time the specified seconds after the given datetime.

--- a/test/good_times_test.exs
+++ b/test/good_times_test.exs
@@ -7,6 +7,11 @@ defmodule GoodTimesTest do
   end
 
   @a_datetime {{2015, 2, 27}, {18, 30, 45}}
+
+  test "at" do
+    assert at(@a_datetime, {10, 30, 15}) == {{2015, 2, 27}, {10, 30, 15}}
+  end
+
   test "seconds_after" do
     assert seconds_after(10, @a_datetime) == {{2015, 2, 27}, {18, 30, 55}}
   end


### PR DESCRIPTION
This is intended to be last part of a pipeline for adjusting any datetime with a specific time. This way, there's no need to change the existing functions to take an optional `at: <time>` argument.

```elixir
two_months_from_now |> at {12, 15, 0}   # => {{2015, 5, 9}, {12, 15, 0}}
```

This PR also splits the type `datetime` into `date` and `time` respectively.