### PR TITLE
Beginning and end

### DIFF
--- a/lib/good_times/boundary.ex
+++ b/lib/good_times/boundary.ex
@@ -22,7 +22,6 @@ defmodule GoodTimes.Boundary do
 
       iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_minute
       {{2015, 2, 27}, {18, 30, 59}}
-
   """
   @spec end_of_minute(GoodTimes.datetime) :: GoodTimes.datetime
   def end_of_minute({date, {hour, minute, _}}) do
@@ -51,7 +50,6 @@ defmodule GoodTimes.Boundary do
 
       iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_hour
       {{2015, 2, 27}, {18, 59, 59}}
-
   """
   @spec end_of_hour(GoodTimes.datetime) :: GoodTimes.datetime
   def end_of_hour({date, {hour, _, _}}) do
@@ -80,7 +78,6 @@ defmodule GoodTimes.Boundary do
 
       iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_day
       {{2015, 2, 27}, {23, 59, 59}}
-
   """
   @spec end_of_day(GoodTimes.datetime) :: GoodTimes.datetime
   def end_of_day({date, _}) do
@@ -109,7 +106,6 @@ defmodule GoodTimes.Boundary do
 
       iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_month
       {{2015, 2, 28}, {23, 59, 59}}
-
   """
   @spec end_of_month(GoodTimes.datetime) :: GoodTimes.datetime
   def end_of_month({{year, month, _}, _}) do
@@ -138,7 +134,6 @@ defmodule GoodTimes.Boundary do
 
       iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_year
       {{2015, 12, 31}, {23, 59, 59}}
-
   """
   @spec end_of_year(GoodTimes.datetime) :: GoodTimes.datetime
   def end_of_year({{year, _, _}, _}) do

--- a/lib/good_times/boundary.ex
+++ b/lib/good_times/boundary.ex
@@ -26,9 +26,7 @@ defmodule GoodTimes.Boundary do
       {{2015, 2, 27}, {18, 30, 0}}
   """
   @spec beginning_of_minute(GoodTimes.datetime) :: GoodTimes.datetime
-  def beginning_of_minute({date, {hour, minute, _}}) do
-    {date, {hour, minute, 0}}
-  end
+  def beginning_of_minute({date, {hour, minute, _}}), do: {date, {hour, minute, 0}}
 
 
   @doc """
@@ -40,9 +38,7 @@ defmodule GoodTimes.Boundary do
       {{2015, 2, 27}, {18, 30, 59}}
   """
   @spec end_of_minute(GoodTimes.datetime) :: GoodTimes.datetime
-  def end_of_minute({date, {hour, minute, _}}) do
-    {date, {hour, minute, 59}}
-  end
+  def end_of_minute({date, {hour, minute, _}}), do: {date, {hour, minute, 59}}
 
 
   @doc """
@@ -54,9 +50,7 @@ defmodule GoodTimes.Boundary do
       {{2015, 2, 27}, {18, 0, 0}}
   """
   @spec beginning_of_hour(GoodTimes.datetime) :: GoodTimes.datetime
-  def beginning_of_hour({date, {hour, _, _}}) do
-    {date, {hour, 0, 0}}
-  end
+  def beginning_of_hour({date, {hour, _, _}}), do: {date, {hour, 0, 0}}
 
 
   @doc """
@@ -68,9 +62,7 @@ defmodule GoodTimes.Boundary do
       {{2015, 2, 27}, {18, 59, 59}}
   """
   @spec end_of_hour(GoodTimes.datetime) :: GoodTimes.datetime
-  def end_of_hour({date, {hour, _, _}}) do
-    {date, {hour, 59, 59}}
-  end
+  def end_of_hour({date, {hour, _, _}}), do: {date, {hour, 59, 59}}
 
 
   @doc """
@@ -82,9 +74,7 @@ defmodule GoodTimes.Boundary do
       {{2015, 2, 27}, {0, 0, 0}}
   """
   @spec beginning_of_day(GoodTimes.datetime) :: GoodTimes.datetime
-  def beginning_of_day({date, _}) do
-    {date, {0, 0, 0}}
-  end
+  def beginning_of_day({date, _}), do: {date, {0, 0, 0}}
 
 
   @doc """
@@ -96,9 +86,7 @@ defmodule GoodTimes.Boundary do
       {{2015, 2, 27}, {23, 59, 59}}
   """
   @spec end_of_day(GoodTimes.datetime) :: GoodTimes.datetime
-  def end_of_day({date, _}) do
-    {date, {23, 59, 59}}
-  end
+  def end_of_day({date, _}), do: {date, {23, 59, 59}}
 
 
   @doc """
@@ -148,9 +136,7 @@ defmodule GoodTimes.Boundary do
       {{2015, 2, 1}, {0, 0, 0}}
   """
   @spec beginning_of_month(GoodTimes.datetime) :: GoodTimes.datetime
-  def beginning_of_month({{year, month, _}, _}) do
-    {{year, month, 1}, {0, 0, 0}}
-  end
+  def beginning_of_month({{year, month, _}, _}), do: {{year, month, 1}, {0, 0, 0}}
 
 
   @doc """
@@ -176,9 +162,7 @@ defmodule GoodTimes.Boundary do
       {{2015, 1, 1}, {0, 0, 0}}
   """
   @spec beginning_of_year(GoodTimes.datetime) :: GoodTimes.datetime
-  def beginning_of_year({{year, _, _}, _}) do
-    {{year, 1, 1}, {0, 0, 0}}
-  end
+  def beginning_of_year({{year, _, _}, _}), do: {{year, 1, 1}, {0, 0, 0}}
 
 
   @doc """
@@ -190,7 +174,5 @@ defmodule GoodTimes.Boundary do
       {{2015, 12, 31}, {23, 59, 59}}
   """
   @spec end_of_year(GoodTimes.datetime) :: GoodTimes.datetime
-  def end_of_year({{year, _, _}, _}) do
-    {{year, 12, 31}, {23, 59, 59}}
-  end
+  def end_of_year({{year, _, _}, _}), do: {{year, 12, 31}, {23, 59, 59}}
 end

--- a/lib/good_times/boundary.ex
+++ b/lib/good_times/boundary.ex
@@ -86,6 +86,44 @@ defmodule GoodTimes.Boundary do
 
 
   @doc """
+  Returns the UTC date and time at the start of the given datetime's week.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> beginning_of_week
+      {{2015, 2, 27}, {0, 0, 0}}
+  """
+  @spec beginning_of_week(GoodTimes.datetime) :: GoodTimes.datetime
+  def beginning_of_week(datetime) do
+    datetime
+    |> GoodTimes.Generate.all_days_before
+    |> find_weekday(1)
+    |> GoodTimes.at {0, 0, 0}
+  end
+
+
+  @doc """
+  Returns the UTC date and time at the end of the given datetime's week.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_week
+      {{2015, 2, 27}, {23, 59, 59}}
+  """
+  @spec end_of_week(GoodTimes.datetime) :: GoodTimes.datetime
+  def end_of_week(datetime) do
+    datetime
+    |> GoodTimes.Generate.all_days_after
+    |> find_weekday(7)
+    |> GoodTimes.at {23, 59, 59}
+  end
+
+  defp find_weekday(stream, weekday) do
+    stream |> Enum.find(fn {date, _} -> weekday == :calendar.day_of_the_week date  end)
+  end
+
+
+  @doc """
   Returns the UTC date and time at the start of the given datetime's month.
 
   ## Examples

--- a/lib/good_times/boundary.ex
+++ b/lib/good_times/boundary.ex
@@ -10,8 +10,8 @@ defmodule GoodTimes.Boundary do
       {{2015, 2, 27}, {18, 30, 0}}
   """
   @spec beginning_of_minute(GoodTimes.datetime) :: GoodTimes.datetime
-  def beginning_of_minute({date, {h, m, _}}) do
-    {date, {h, m, 0}}
+  def beginning_of_minute({date, {hour, minute, _}}) do
+    {date, {hour, minute, 0}}
   end
 
 
@@ -25,8 +25,8 @@ defmodule GoodTimes.Boundary do
 
   """
   @spec end_of_minute(GoodTimes.datetime) :: GoodTimes.datetime
-  def end_of_minute({date, {h, m, _}}) do
-    {date, {h, m, 59}}
+  def end_of_minute({date, {hour, minute, _}}) do
+    {date, {hour, minute, 59}}
   end
 
 
@@ -39,8 +39,8 @@ defmodule GoodTimes.Boundary do
       {{2015, 2, 27}, {18, 0, 0}}
   """
   @spec beginning_of_hour(GoodTimes.datetime) :: GoodTimes.datetime
-  def beginning_of_hour({date, {h, _, _}}) do
-    {date, {h, 0, 0}}
+  def beginning_of_hour({date, {hour, _, _}}) do
+    {date, {hour, 0, 0}}
   end
 
 
@@ -54,8 +54,8 @@ defmodule GoodTimes.Boundary do
 
   """
   @spec end_of_hour(GoodTimes.datetime) :: GoodTimes.datetime
-  def end_of_hour({date, {h, _, _}}) do
-    {date, {h, 59, 59}}
+  def end_of_hour({date, {hour, _, _}}) do
+    {date, {hour, 59, 59}}
   end
 
 
@@ -97,8 +97,8 @@ defmodule GoodTimes.Boundary do
       {{2015, 2, 1}, {0, 0, 0}}
   """
   @spec beginning_of_month(GoodTimes.datetime) :: GoodTimes.datetime
-  def beginning_of_month({{y, m, _}, _}) do
-    {{y, m, 1}, {0, 0, 0}}
+  def beginning_of_month({{year, month, _}, _}) do
+    {{year, month, 1}, {0, 0, 0}}
   end
 
 
@@ -112,8 +112,8 @@ defmodule GoodTimes.Boundary do
 
   """
   @spec end_of_month(GoodTimes.datetime) :: GoodTimes.datetime
-  def end_of_month({{y, m, _}, _}) do
-    {{y, m, :calendar.last_day_of_the_month(y, m)}, {23, 59, 59}}
+  def end_of_month({{year, month, _}, _}) do
+    {{year, month, :calendar.last_day_of_the_month(year, month)}, {23, 59, 59}}
   end
 
 
@@ -126,8 +126,8 @@ defmodule GoodTimes.Boundary do
       {{2015, 1, 1}, {0, 0, 0}}
   """
   @spec beginning_of_year(GoodTimes.datetime) :: GoodTimes.datetime
-  def beginning_of_year({{y, _, _}, _}) do
-    {{y, 1, 1}, {0, 0, 0}}
+  def beginning_of_year({{year, _, _}, _}) do
+    {{year, 1, 1}, {0, 0, 0}}
   end
 
 
@@ -141,7 +141,7 @@ defmodule GoodTimes.Boundary do
 
   """
   @spec end_of_year(GoodTimes.datetime) :: GoodTimes.datetime
-  def end_of_year({{y, _, _}, _}) do
-    {{y, 12, 31}, {23, 59, 59}}
+  def end_of_year({{year, _, _}, _}) do
+    {{year, 12, 31}, {23, 59, 59}}
   end
 end

--- a/lib/good_times/boundary.ex
+++ b/lib/good_times/boundary.ex
@@ -1,4 +1,6 @@
 defmodule GoodTimes.Boundary do
+  @vsn GoodTimes.version
+
   @doc """
   Returns the UTC date and time at the start of the given datetime's minute.
 

--- a/lib/good_times/boundary.ex
+++ b/lib/good_times/boundary.ex
@@ -1,6 +1,22 @@
 defmodule GoodTimes.Boundary do
   @vsn GoodTimes.version
 
+  @moduledoc """
+  Find the boundaries of a unit of time, i.e. the first/last second of a minute,
+  an hour, day, week, month or year.
+
+  All functions take the form `beginning_of_<time unit>/1` and `end_of_<time unit>/1`.
+  They operate on and return an Erlang datetime based on the Coordinated Universal
+  Time (UTC).
+
+  Example:
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_month
+      {{2015, 2, 28}, {23, 59, 59}}
+
+  """
+
+
   @doc """
   Returns the UTC date and time at the start of the given datetime's minute.
 

--- a/lib/good_times/boundary.ex
+++ b/lib/good_times/boundary.ex
@@ -9,11 +9,10 @@ defmodule GoodTimes.Boundary do
   They operate on and return an Erlang datetime based on the Coordinated Universal
   Time (UTC).
 
-  Example:
+  ## Examples
 
       iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_month
       {{2015, 2, 28}, {23, 59, 59}}
-
   """
 
 

--- a/lib/good_times/boundary.ex
+++ b/lib/good_times/boundary.ex
@@ -1,0 +1,15 @@
+defmodule GoodTimes.Boundary do
+  @doc """
+  Returns the UTC date and time at the start of the given datetime's minute.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> beginning_of_minute
+      {{2015, 2, 27}, {18, 30, 0}}
+
+  """
+  @spec beginning_of_minute(GoodTimes.datetime) :: GoodTimes.datetime
+  def beginning_of_minute({date, {h, m, _}}) do
+    {date, {h, m, 0}}
+  end
+end

--- a/lib/good_times/boundary.ex
+++ b/lib/good_times/boundary.ex
@@ -6,10 +6,140 @@ defmodule GoodTimes.Boundary do
 
       iex> {{2015, 2, 27}, {18, 30, 45}} |> beginning_of_minute
       {{2015, 2, 27}, {18, 30, 0}}
-
   """
   @spec beginning_of_minute(GoodTimes.datetime) :: GoodTimes.datetime
   def beginning_of_minute({date, {h, m, _}}) do
     {date, {h, m, 0}}
+  end
+
+
+  @doc """
+  Returns the UTC date and time at the end of the given datetime's minute.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_minute
+      {{2015, 2, 27}, {18, 30, 59}}
+
+  """
+  @spec end_of_minute(GoodTimes.datetime) :: GoodTimes.datetime
+  def end_of_minute({date, {h, m, _}}) do
+    {date, {h, m, 59}}
+  end
+
+
+  @doc """
+  Returns the UTC date and time at the start of the given datetime's hour.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> beginning_of_hour
+      {{2015, 2, 27}, {18, 0, 0}}
+  """
+  @spec beginning_of_hour(GoodTimes.datetime) :: GoodTimes.datetime
+  def beginning_of_hour({date, {h, _, _}}) do
+    {date, {h, 0, 0}}
+  end
+
+
+  @doc """
+  Returns the UTC date and time at the end of the given datetime's hour.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_hour
+      {{2015, 2, 27}, {18, 59, 59}}
+
+  """
+  @spec end_of_hour(GoodTimes.datetime) :: GoodTimes.datetime
+  def end_of_hour({date, {h, _, _}}) do
+    {date, {h, 59, 59}}
+  end
+
+
+  @doc """
+  Returns the UTC date and time at the start of the given datetime's day.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> beginning_of_day
+      {{2015, 2, 27}, {0, 0, 0}}
+  """
+  @spec beginning_of_day(GoodTimes.datetime) :: GoodTimes.datetime
+  def beginning_of_day({date, _}) do
+    {date, {0, 0, 0}}
+  end
+
+
+  @doc """
+  Returns the UTC date and time at the end of the given datetime's day.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_day
+      {{2015, 2, 27}, {23, 59, 59}}
+
+  """
+  @spec end_of_day(GoodTimes.datetime) :: GoodTimes.datetime
+  def end_of_day({date, _}) do
+    {date, {23, 59, 59}}
+  end
+
+
+  @doc """
+  Returns the UTC date and time at the start of the given datetime's month.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> beginning_of_month
+      {{2015, 2, 1}, {0, 0, 0}}
+  """
+  @spec beginning_of_month(GoodTimes.datetime) :: GoodTimes.datetime
+  def beginning_of_month({{y, m, _}, _}) do
+    {{y, m, 1}, {0, 0, 0}}
+  end
+
+
+  @doc """
+  Returns the UTC date and time at the end of the given datetime's month.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_month
+      {{2015, 2, 28}, {23, 59, 59}}
+
+  """
+  @spec end_of_month(GoodTimes.datetime) :: GoodTimes.datetime
+  def end_of_month({{y, m, _}, _}) do
+    {{y, m, :calendar.last_day_of_the_month(y, m)}, {23, 59, 59}}
+  end
+
+
+  @doc """
+  Returns the UTC date and time at the start of the given datetime's year.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> beginning_of_year
+      {{2015, 1, 1}, {0, 0, 0}}
+  """
+  @spec beginning_of_year(GoodTimes.datetime) :: GoodTimes.datetime
+  def beginning_of_year({{y, _, _}, _}) do
+    {{y, 1, 1}, {0, 0, 0}}
+  end
+
+
+  @doc """
+  Returns the UTC date and time at the end of the given datetime's year.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> end_of_year
+      {{2015, 12, 31}, {23, 59, 59}}
+
+  """
+  @spec end_of_year(GoodTimes.datetime) :: GoodTimes.datetime
+  def end_of_year({{y, _, _}, _}) do
+    {{y, 12, 31}, {23, 59, 59}}
   end
 end

--- a/test/good_times/boundary_test.exs
+++ b/test/good_times/boundary_test.exs
@@ -28,16 +28,16 @@ defmodule GoodTimes.BoundaryTest do
     assert @a_datetime |> end_of_day == {{2015, 2, 27}, {23, 59, 59}}
   end
 
-  @a_monday {{2015, 2, 23}, {18, 30, 45}}
+  @beginning_of_monday {{2015, 2, 23}, {0, 0, 0}}
   test "beginning_of_week" do
-    assert @a_datetime |> beginning_of_week == {{2015, 2, 23}, {0, 0, 0}}
-    assert @a_monday |> beginning_of_week == {{2015, 2, 23}, {0, 0, 0}}
+    assert @a_datetime |> beginning_of_week == @beginning_of_monday
+    assert @beginning_of_monday |> beginning_of_week == {{2015, 2, 23}, {0, 0, 0}}
   end
 
-  @a_sunday {{2015, 3, 1}, {18, 30, 45}}
+  @end_of_sunday {{2015, 3, 1}, {23, 59, 59}}
   test "end_of_week" do
-    assert @a_datetime |> end_of_week == {{2015, 3, 1}, {23, 59, 59}}
-    assert @a_sunday |> end_of_week == {{2015, 3, 1}, {23, 59, 59}}
+    assert @a_datetime |> end_of_week == @end_of_sunday
+    assert @end_of_sunday |> end_of_week == @end_of_sunday
   end
 
   test "beginning_of_month" do

--- a/test/good_times/boundary_test.exs
+++ b/test/good_times/boundary_test.exs
@@ -1,0 +1,10 @@
+defmodule GoodTimes.BoundaryTest do
+  use ExUnit.Case
+  import GoodTimes.Boundary
+
+  @a_datetime {{2015, 2, 27}, {18, 30, 45}}
+
+  test "beginning_of_minute" do
+    assert @a_datetime |> beginning_of_minute == {{2015, 2, 27}, {18, 30, 00}}
+  end
+end

--- a/test/good_times/boundary_test.exs
+++ b/test/good_times/boundary_test.exs
@@ -28,12 +28,16 @@ defmodule GoodTimes.BoundaryTest do
     assert @a_datetime |> end_of_day == {{2015, 2, 27}, {23, 59, 59}}
   end
 
+  @a_monday {{2015, 2, 23}, {18, 30, 45}}
   test "beginning_of_week" do
     assert @a_datetime |> beginning_of_week == {{2015, 2, 23}, {0, 0, 0}}
+    assert @a_monday |> beginning_of_week == {{2015, 2, 23}, {0, 0, 0}}
   end
 
+  @a_sunday {{2015, 3, 1}, {18, 30, 45}}
   test "end_of_week" do
     assert @a_datetime |> end_of_week == {{2015, 3, 1}, {23, 59, 59}}
+    assert @a_sunday |> end_of_week == {{2015, 3, 1}, {23, 59, 59}}
   end
 
   test "beginning_of_month" do

--- a/test/good_times/boundary_test.exs
+++ b/test/good_times/boundary_test.exs
@@ -28,8 +28,13 @@ defmodule GoodTimes.BoundaryTest do
     assert @a_datetime |> end_of_day == {{2015, 2, 27}, {23, 59, 59}}
   end
 
-  # test "beginning_of_week"
-  # test "end_of_week"
+  test "beginning_of_week" do
+    assert @a_datetime |> beginning_of_week == {{2015, 2, 23}, {0, 0, 0}}
+  end
+
+  test "end_of_week" do
+    assert @a_datetime |> end_of_week == {{2015, 3, 1}, {23, 59, 59}}
+  end
 
   test "beginning_of_month" do
     assert @a_datetime |> beginning_of_month == {{2015, 2, 1}, {0, 0, 0}}

--- a/test/good_times/boundary_test.exs
+++ b/test/good_times/boundary_test.exs
@@ -5,6 +5,47 @@ defmodule GoodTimes.BoundaryTest do
   @a_datetime {{2015, 2, 27}, {18, 30, 45}}
 
   test "beginning_of_minute" do
-    assert @a_datetime |> beginning_of_minute == {{2015, 2, 27}, {18, 30, 00}}
+    assert @a_datetime |> beginning_of_minute == {{2015, 2, 27}, {18, 30, 0}}
+  end
+
+  test "end_of_minute" do
+    assert @a_datetime |> end_of_minute == {{2015, 2, 27}, {18, 30, 59}}
+  end
+
+  test "beginning_of_hour" do
+    assert @a_datetime |> beginning_of_hour == {{2015, 2, 27}, {18, 0, 0}}
+  end
+
+  test "end_of_hour" do
+    assert @a_datetime |> end_of_hour == {{2015, 2, 27}, {18, 59, 59}}
+  end
+
+  test "beginning_of_day" do
+    assert @a_datetime |> beginning_of_day == {{2015, 2, 27}, {0, 0, 0}}
+  end
+
+  test "end_of_day" do
+    assert @a_datetime |> end_of_day == {{2015, 2, 27}, {23, 59, 59}}
+  end
+
+  # test "beginning_of_week"
+  # test "end_of_week"
+
+  test "beginning_of_month" do
+    assert @a_datetime |> beginning_of_month == {{2015, 2, 1}, {0, 0, 0}}
+  end
+
+  @feb_2016 {{2016, 2, 27}, {12, 0, 0}}
+  test "end_of_month" do
+    assert @a_datetime |> end_of_month == {{2015, 2, 28}, {23, 59, 59}}
+    assert @feb_2016 |> end_of_month == {{2016, 2, 29}, {23, 59, 59}}
+  end
+
+  test "beginning_of_year" do
+    assert @a_datetime |> beginning_of_year == {{2015, 1, 1}, {0, 0, 0}}
+  end
+
+  test "end_of_year" do
+    assert @a_datetime |> end_of_year == {{2015, 12, 31}, {23, 59, 59}}
   end
 end


### PR DESCRIPTION
Functions that return the beginning or end datetime at a certain time unit from a given datetime. See #19.

Example:

    iex> {{2015, 2, 27}, {18, 30, 45}} |> beginning_of_year
    {{2015, 1, 1}, {0, 0, 0}}
