### PR TITLE
Doctest what we can, improve remaining test cases

### DIFF
--- a/test/good_times_test.exs
+++ b/test/good_times_test.exs
@@ -1,6 +1,17 @@
 defmodule GoodTimesTest do
   use ExUnit.Case
   import GoodTimes
+  doctest GoodTimes, except: [
+    nil, # to exclude moduledoc
+    now: 0, at: 2,
+    seconds_from_now: 1, a_second_from_now: 0, seconds_ago: 1, a_second_ago: 0,
+    minutes_from_now: 1, a_minute_from_now: 0, minutes_ago: 1, a_minute_ago: 0,
+    hours_from_now: 1, an_hour_from_now: 0, hours_ago: 1, an_hour_ago: 0,
+    days_from_now: 1, a_day_from_now: 0, days_ago: 1, a_day_ago: 0,
+    weeks_from_now: 1, a_week_from_now: 0, weeks_ago: 1, a_week_ago: 0,
+    months_from_now: 1, a_month_from_now: 0, months_ago: 1, a_month_ago: 0,
+    years_from_now: 1, a_year_from_now: 0, years_ago: 1, a_year_ago: 0
+  ]
 
   test "now" do
     assert now == :calendar.universal_time
@@ -15,22 +26,6 @@ defmodule GoodTimesTest do
 
   test "at when passed a date" do
     assert at(@a_date, {10, 30, 15}) == {{2015, 2, 27}, {10, 30, 15}}
-  end
-
-  test "seconds_after" do
-    assert seconds_after(10, @a_datetime) == {{2015, 2, 27}, {18, 30, 55}}
-  end
-
-  test "seconds_before" do
-    assert seconds_before(10, @a_datetime) == {{2015, 2, 27}, {18, 30, 35}}
-  end
-
-  test "a_second_after" do
-    assert a_second_after(@a_datetime) == {{2015, 2, 27}, {18, 30, 46}}
-  end
-
-  test "a_second_before" do
-    assert a_second_before(@a_datetime) == {{2015, 2, 27}, {18, 30, 44}}
   end
 
   test "seconds_from_now" do
@@ -49,22 +44,6 @@ defmodule GoodTimesTest do
     assert a_second_ago == a_second_before now
   end
 
-  test "minutes_after" do
-    assert minutes_after(10, @a_datetime) == {{2015, 2, 27}, {18, 40, 45}}
-  end
-
-  test "minutes_before" do
-    assert minutes_before(10, @a_datetime) == {{2015, 2, 27}, {18, 20, 45}}
-  end
-
-  test "a_minute_after" do
-    assert a_minute_after(@a_datetime) == {{2015, 2, 27}, {18, 31, 45}}
-  end
-
-  test "a_minute_before" do
-    assert a_minute_before(@a_datetime) == {{2015, 2, 27}, {18, 29, 45}}
-  end
-
   test "minutes_from_now" do
     assert minutes_from_now(5) == minutes_after(5, now)
   end
@@ -79,22 +58,6 @@ defmodule GoodTimesTest do
 
   test "a_minute_ago" do
     assert a_minute_ago == a_minute_before now
-  end
-
-  test "hours_after" do
-    assert hours_after(10, @a_datetime) == {{2015, 2, 28}, {4, 30, 45}}
-  end
-
-  test "hours_before" do
-    assert hours_before(10, @a_datetime) == {{2015, 2, 27}, {8, 30, 45}}
-  end
-
-  test "an_hour_after" do
-    assert an_hour_after(@a_datetime) == {{2015, 2, 27}, {19, 30, 45}}
-  end
-
-  test "an_hour_before" do
-    assert an_hour_before(@a_datetime) == {{2015, 2, 27}, {17, 30, 45}}
   end
 
   test "hours_from_now" do
@@ -113,22 +76,6 @@ defmodule GoodTimesTest do
     assert an_hour_ago == an_hour_before now
   end
 
-  test "days_after" do
-    assert days_after(3, @a_datetime) == {{2015, 3, 2}, {18, 30, 45}}
-  end
-
-  test "days_before" do
-    assert days_before(3, @a_datetime) == {{2015, 2, 24}, {18, 30, 45}}
-  end
-
-  test "a_day_after" do
-    assert a_day_after(@a_datetime) == {{2015, 2, 28}, {18, 30, 45}}
-  end
-
-  test "a_day_before" do
-    assert a_day_before(@a_datetime) == {{2015, 2, 26}, {18, 30, 45}}
-  end
-
   test "days_from_now" do
     assert days_from_now(3) == days_after(3, now)
   end
@@ -143,22 +90,6 @@ defmodule GoodTimesTest do
 
   test "a_day_ago" do
     assert a_day_ago == a_day_before now
-  end
-
-  test "weeks_after" do
-    assert weeks_after(4, @a_datetime) == {{2015, 3, 27}, {18, 30, 45}}
-  end
-
-  test "weeks_before" do
-    assert weeks_before(4, @a_datetime) == {{2015, 1, 30}, {18, 30, 45}}
-  end
-
-  test "a_week_after" do
-    assert a_week_after(@a_datetime) == {{2015, 3, 6}, {18, 30, 45}}
-  end
-
-  test "a_week_before" do
-    assert a_week_before(@a_datetime) == {{2015, 2, 20}, {18, 30, 45}}
   end
 
   test "weeks_from_now" do
@@ -178,26 +109,24 @@ defmodule GoodTimesTest do
   end
 
   @last_jan_2015 {{2015, 1, 31}, {12, 0, 0}}
-  test "months_after" do
-    assert months_after(1, @a_datetime) == {{2015, 3, 27}, {18, 30, 45}}
+  test "months_after to a shorter month" do
     assert months_after(1, @last_jan_2015) == {{2015, 2, 28}, {12, 0, 0}}
+  end
+
+  test "months_after wrapping around to the next year" do
     assert months_after(12, @last_jan_2015) == {{2016, 1, 31}, {12, 0, 0}}
+  end
+
+  test "months_after picks the correct last day of the month" do
     assert months_after(13, @last_jan_2015) == {{2016, 2, 29}, {12, 0, 0}}
   end
 
-  test "months_before" do
-    assert months_before(1, @a_datetime) == {{2015, 1, 27}, {18, 30, 45}}
-    assert months_before(1, @last_jan_2015) == {{2014, 12, 31}, {12, 0, 0}}
-    assert months_before(12, @last_jan_2015) == {{2014, 1, 31}, {12, 0, 0}}
+  test "months_before to a shorter month" do
     assert months_before(11, @last_jan_2015) == {{2014, 2, 28}, {12, 0, 0}}
   end
 
-  test "a_month_after" do
-    assert a_month_after(@a_datetime) == {{2015, 3, 27}, {18, 30, 45}}
-  end
-
-  test "a_month_before" do
-    assert a_month_before(@a_datetime) == {{2015, 1, 27}, {18, 30, 45}}
+  test "months_before wrapping around to the previous year" do
+    assert months_before(1, @last_jan_2015) == {{2014, 12, 31}, {12, 0, 0}}
   end
 
   test "months_from_now" do
@@ -216,21 +145,8 @@ defmodule GoodTimesTest do
     assert a_month_ago == a_month_before now
   end
 
-  test "years_after" do
-    assert years_after(4, @a_datetime) == {{2019, 2, 27}, {18, 30, 45}}
+  test "years_after a leap day" do
     assert years_after(1, {{2016, 2, 29}, {12, 0, 0}}) == {{2017, 2, 28}, {12, 0, 0}}
-  end
-
-  test "years_before" do
-    assert years_before(4, @a_datetime) == {{2011, 2, 27}, {18, 30, 45}}
-  end
-
-  test "a_year_after" do
-    assert a_year_after(@a_datetime) == {{2016, 2, 27}, {18, 30, 45}}
-  end
-
-  test "a_year_before" do
-    assert a_year_before(@a_datetime) == {{2014, 2, 27}, {18, 30, 45}}
   end
 
   test "years_from_now" do


### PR DESCRIPTION
Exploit the fact that moduledoc can be excluded by providing `nil` instead of
a function arity tuple. Exclude all tests that use `now`. Remove duplicate
test cases. Where we had multiple asserts, break them out to better named,
individual test cases.