### PR TITLE
Add ~d, ~t, and ~D sigils for constructing dates, times, and datetimes.

### DIFF
--- a/lib/good_times/sigil.ex
+++ b/lib/good_times/sigil.ex
@@ -1,0 +1,51 @@
+defmodule GoodTimes.Sigil do
+  @vsn GoodTimes.version
+
+  @moduledoc """
+  Provides sigils for constructing dates, times, and datetimes.
+  """
+
+  @doc """
+  Handles the sigil ~d. Returns a date tuple.
+
+  ## Examples
+
+      iex> ~d(2015-03-21)
+      {2015, 03, 21}
+  """
+  def sigil_d(date_string, []) do
+    date_string |> parse_into_tuple("-")
+  end
+
+  @doc """
+  Handles the sigil ~t. Returns a time tuple.
+
+  ## Examples
+
+      iex> ~t(11:51:24)
+      {11, 51, 24}
+  """
+  def sigil_t(time_string, []) do
+    time_string |> parse_into_tuple(":")
+  end
+
+  @doc """
+  Handles the sigil ~D. Returns a datetime tuple.
+
+  ## Examples
+
+      iex> ~D(2015-03-21 11:51:24)
+      {{2015, 03, 21}, {11, 51, 24}}
+  """
+  def sigil_D(datetime_string, []) do
+    [date, time] = String.split(datetime_string)
+    {sigil_d(date, []), sigil_t(time, [])}
+  end
+
+  defp parse_into_tuple(string, separator) do
+    string
+    |> String.split(separator)
+    |> Enum.map(&String.to_integer/1)
+    |> List.to_tuple
+  end
+end

--- a/test/good_times/date_test.exs
+++ b/test/good_times/date_test.exs
@@ -9,7 +9,6 @@ defmodule GoodTimes.DateTest do
   end
 
   test "tomorrow" do
-
     assert tomorrow == to_date(a_day_from_now)
   end
 

--- a/test/good_times/sigil_test.exs
+++ b/test/good_times/sigil_test.exs
@@ -1,0 +1,4 @@
+defmodule GoodTimes.SigilTest do
+  use ExUnit.Case, async: true
+  doctest GoodTimes.Sigil, import: true
+end


### PR DESCRIPTION
This PR adds three sigils that can be used to create dates, times, and datetimes.

I'm considering merging some or all of these sigils into one, letting it handle different inputs and use modifiers to determine the return value.

E.g. using the modifier `d` to return a `date` rather than a `datetime`. This would be [similar](http://elixir-lang.org/getting-started/sigils.html#word-lists) to the way `~w` works with it's modifiers `a`, `c`, and `s.`

```elixir
iex> ~D(2015-03-21 19:16:45)
{{2015, 3, 21}, {19, 16, 45}}

iex> ~D(2015-03-21 19:16:45)d
{2015, 3, 21}

iex> ~D(2015-03-21)
{{2015, 3, 21}, {0, 0, 0}}

iex> ~D(2015-03-21)d
{2015, 3, 21}
```

Not sure how to handle times in this case. The modifier `t` can of course be used to return the time portion and the input parsing could handle `~D(12:15:30)t`, but then `~D(12:15:30)` would hardly make any sense (see our previous discussion on a `from_time` conversion function). 